### PR TITLE
Add sync wave annotation to Volsync app

### DIFF
--- a/kubernetes/infrastructure/volsync/app.yaml
+++ b/kubernetes/infrastructure/volsync/app.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: volsync
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   project: default
   source:


### PR DESCRIPTION
## Summary
- add Argo CD sync wave annotation to Volsync application manifest

## Testing
- `pre-commit run --files kubernetes/infrastructure/volsync/app.yaml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68b75112e710832e92d763d8d249c84b