### PR TITLE
chore: update backup app repo URL

### DIFF
--- a/kubernetes/infrastructure/backup/app.yaml
+++ b/kubernetes/infrastructure/backup/app.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/your-org/BrainiacOps.git
+    repoURL: https://github.com/hevel86/BrainiacOps
     targetRevision: HEAD
     path: kubernetes/storage/backup
   destination:


### PR DESCRIPTION
## Summary
- replace placeholder repo URL with actual repository

## Testing
- `bash .githooks/pre-commit` *(fails: Docker CLI not found → skipping TruffleHog scan)*

------
https://chatgpt.com/codex/tasks/task_e_68b751e31264832ea7ecbf27b6ebd882